### PR TITLE
Update @dolittle/build.aurelia version

### DIFF
--- a/Content/package.json
+++ b/Content/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@dolittle/build.aurelia": "3.3.0",
+    "@dolittle/build.aurelia": "3.3.2",
     "@dolittle/styles": "^3.0.2",
     "babel-eslint": "^10.0.1",
     "eslint": "^5.14.1",


### PR DESCRIPTION
The newer version ships with the correct bluebird version. Otherwise the boilerplate breaks as defined in here:
https://community.dolittle.com/t/aurelia-frontend-module-not-found-error-cant-resolve-async-hooks-in-bluebirdjs/37

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1158158625987576)
